### PR TITLE
fix(cart): no longer grab extra byte when loading

### DIFF
--- a/cart.cpp
+++ b/cart.cpp
@@ -17,7 +17,7 @@ namespace cash::GB
       size++;
       file.get();
     }
-
+    size--;
     rom = new bit8[size];
     file.close();
     file.open(fileName);
@@ -110,6 +110,7 @@ namespace cash::GB
     out << "ramBank: \t" << cart.ramBanks << endl;
     out << "destination: \t" << (cart.destination ? "Japan" : "Worldwide") << endl;
     out << "version: \t" << +cart.version << endl;
+    out << "global checksum:" << std::hex << ((cart.rom[0x014E] << 8) | cart.rom[0x014F]) << endl;
 
     return out;
   }

--- a/cashgb.cpp
+++ b/cashgb.cpp
@@ -13,6 +13,5 @@ int main(int argc, char **argv)
 
   cash::GB::Cart cart = Cart(std::string(argv[1]));
   std::cout << cart << std::endl;
-  cash::GB::
   return 0;
 }

--- a/cpu.h
+++ b/cpu.h
@@ -154,7 +154,7 @@ namespace cash::GB
     bit16 memLoc = 0x0000;
     bit16 value = 0x0000;
     bit8 cycle = 0x00;
-    const Instruction const *currentInstruction;
+    const Instruction *currentInstruction;
     bool IME = false;
     bool stopSystem = false;
     bool stopMain = false;


### PR DESCRIPTION
this causes the global check sum to pass correctly.